### PR TITLE
Fix namespaces in test classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "autoload": {
         "psr-4": {
-            "TheIconic\\Fixtures\\": "src/"
+            "TheIconic\\Fixtures\\": "src/",
+            "TheIconic\\Test\\":"tests/TheIconic/"
         }
     }
 }

--- a/tests/TheIconic/Fixtures/Fixture/FixtureCollectionTest.php
+++ b/tests/TheIconic/Fixtures/Fixture/FixtureCollectionTest.php
@@ -1,8 +1,12 @@
 <?php
 
-namespace TheIconic\Fixtures\Fixture;
+namespace TheIconic\Test\Fixtures\Fixture;
 
-class FixtureCollectionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Fixture\Fixture;
+use TheIconic\Fixtures\Fixture\FixtureCollection;
+
+class FixtureCollectionTest extends TestCase
 {
 
     private $testParsedDataCountry = [

--- a/tests/TheIconic/Fixtures/Fixture/FixtureTest.php
+++ b/tests/TheIconic/Fixtures/Fixture/FixtureTest.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace TheIconic\Fixtures\Fixture;
+namespace TheIconic\Test\Fixtures\Fixture;
 
-class FixtureTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Fixture\Fixture;
+
+class FixtureTest extends TestCase
 {
     private $testParsedData = [
         'country' => [

--- a/tests/TheIconic/Fixtures/FixtureManager/FixtureManagerPdoTest.php
+++ b/tests/TheIconic/Fixtures/FixtureManager/FixtureManagerPdoTest.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace TheIconic\Fixtures\FixtureManager;
+namespace TheIconic\Test\Fixtures\FixtureManager;
 
-class FixtureManagerPdoTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\FixtureManager\FixtureManager;
+
+class FixtureManagerPdoTest extends TestCase
 {
     private $fixtures = [
         'customer_address_region_suburb.xml',

--- a/tests/TheIconic/Fixtures/FixtureManager/FixtureManagerRedisTest.php
+++ b/tests/TheIconic/Fixtures/FixtureManager/FixtureManagerRedisTest.php
@@ -1,8 +1,12 @@
 <?php
-namespace TheIconic\Fixtures\FixtureManager;
-use Redis;
 
-class FixtureManagerRedisTest extends \PHPUnit_Framework_TestCase
+namespace TheIconic\Test\Fixtures\FixtureManager;
+
+use PHPUnit\Framework\TestCase;
+use Redis;
+use TheIconic\Fixtures\FixtureManager\FixtureManager;
+
+class FixtureManagerRedisTest extends TestCase
 {
     private $fixtures = [
         'customer_address_region_suburb.xml',

--- a/tests/TheIconic/Fixtures/Parser/JsonParserTest.php
+++ b/tests/TheIconic/Fixtures/Parser/JsonParserTest.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace TheIconic\Fixtures\Parser;
+namespace TheIconic\Test\Fixtures\Parser;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Parser\JsonParser;
 
-class JsonParserTest extends PHPUnit_Framework_TestCase
+class JsonParserTest extends TestCase
 {
     const TESTS_FIXTURES_DIRECTORY = './tests/Support/TestsFixtures/';
 
     /**
-     * @var YamlParser
+     * @var JsonParser
      */
     private $parserInstance;
 

--- a/tests/TheIconic/Fixtures/Parser/MasterParserTest.php
+++ b/tests/TheIconic/Fixtures/Parser/MasterParserTest.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace TheIconic\Fixtures\Parser;
+namespace TheIconic\Test\Fixtures\Parser;
 
-class MasterParserTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Parser\MasterParser;
+
+class MasterParserTest extends TestCase
 {
     const MASTER_PARSER_FULLY_QUALIFIED_NAME = 'TheIconic\Fixtures\Parser\MasterParser';
 

--- a/tests/TheIconic/Fixtures/Parser/XmlParserTest.php
+++ b/tests/TheIconic/Fixtures/Parser/XmlParserTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace TheIconic\Fixtures\Parser;
+namespace TheIconic\Test\Fixtures\Parser;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Parser\XmlParser;
 
-class XmlParserTest extends PHPUnit_Framework_TestCase
+class XmlParserTest extends TestCase
 {
     const TESTS_FIXTURES_DIRECTORY = './tests/Support/TestsFixtures/';
 

--- a/tests/TheIconic/Fixtures/Parser/YamlParserTest.php
+++ b/tests/TheIconic/Fixtures/Parser/YamlParserTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace TheIconic\Fixtures\Parser;
+namespace TheIconic\Test\Fixtures\Parser;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Parser\YamlParser;
 
-class YamlParserTest extends PHPUnit_Framework_TestCase
+class YamlParserTest extends TestCase
 {
     const TESTS_FIXTURES_DIRECTORY = './tests/Support/TestsFixtures/';
 

--- a/tests/TheIconic/Fixtures/Persister/PDO/MySQLPersisterTest.php
+++ b/tests/TheIconic/Fixtures/Persister/PDO/MySQLPersisterTest.php
@@ -1,8 +1,12 @@
 <?php
 
-use TheIconic\Fixtures\Fixture\Fixture;
+namespace TheIconic\Test\Fixtures\Persister\PDO;
 
-class MysqlPersisterTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Fixture\Fixture;
+use TheIconic\Fixtures\Persister\PDO\MysqlPersister;
+
+class MysqlPersisterTest extends TestCase
 {
     private $testParsedData = [
         'country' => [
@@ -31,7 +35,7 @@ class MysqlPersisterTest extends \PHPUnit_Framework_TestCase
     public function testPersist()
     {
 
-        $persister = new TheIconic\Fixtures\Persister\PDO\MysqlPersister(
+        $persister = new MysqlPersister(
             $_ENV['pdo_host'],
             $_ENV['pdo_database'],
             $_ENV['pdo_username'],
@@ -48,7 +52,7 @@ class MysqlPersisterTest extends \PHPUnit_Framework_TestCase
     public function testInvalidPersist()
     {
 
-        $persister = new TheIconic\Fixtures\Persister\PDO\MysqlPersister(
+        $persister = new MysqlPersister(
             $_ENV['pdo_host'],
             $_ENV['pdo_database'],
             $_ENV['pdo_username'],
@@ -60,7 +64,7 @@ class MysqlPersisterTest extends \PHPUnit_Framework_TestCase
 
     public function testCleanStorage()
     {
-        $persister = new TheIconic\Fixtures\Persister\PDO\MysqlPersister(
+        $persister = new MysqlPersister(
             $_ENV['pdo_host'],
             $_ENV['pdo_database'],
             $_ENV['pdo_username'],
@@ -77,7 +81,7 @@ class MysqlPersisterTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConnection()
     {
-        $persister = new TheIconic\Fixtures\Persister\PDO\MysqlPersister(
+        $persister = new MysqlPersister(
             $_ENV['pdo_host'],
             $_ENV['pdo_database'],
             $_ENV['pdo_username'],

--- a/tests/TheIconic/Fixtures/Persister/PDO/PersisterFactoryTest.php
+++ b/tests/TheIconic/Fixtures/Persister/PDO/PersisterFactoryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-namespace TheIconic\Fixtures\Persister\PDO;
+namespace TheIconic\Test\Fixtures\Persister\PDO;
 
-class PersisterFactoryTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Persister\PDO\PersisterFactory;
+
+class PersisterFactoryTest extends TestCase
 {
     public function testCreate()
     {

--- a/tests/TheIconic/Fixtures/Persister/Redis/RedisPersisterTest.php
+++ b/tests/TheIconic/Fixtures/Persister/Redis/RedisPersisterTest.php
@@ -1,8 +1,12 @@
 <?php
 
-use TheIconic\Fixtures\Fixture\Fixture;
+namespace TheIconic\Test\Fixtures\Persister\Redis;
 
-class RedisPersisterTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Fixture\Fixture;
+use TheIconic\Fixtures\Persister\Redis\RedisPersister;
+
+class RedisPersisterTest extends TestCase
 {
     private $testParsedData = [
         'country' => [
@@ -23,7 +27,7 @@ class RedisPersisterTest extends \PHPUnit_Framework_TestCase
 
     public function testPersist()
     {
-        $persister = new TheIconic\Fixtures\Persister\Redis\RedisPersister(
+        $persister = new RedisPersister(
             $_ENV['redis_host'],
             $_ENV['redis_port'],
             $_ENV['redis_db_number'],
@@ -38,7 +42,7 @@ class RedisPersisterTest extends \PHPUnit_Framework_TestCase
 
     public function testPersistNullSerializer()
     {
-        $persister = new TheIconic\Fixtures\Persister\Redis\RedisPersister(
+        $persister = new RedisPersister(
             $_ENV['redis_host'],
             $_ENV['redis_port'],
             $_ENV['redis_db_number'],
@@ -53,7 +57,7 @@ class RedisPersisterTest extends \PHPUnit_Framework_TestCase
 
     public function testPersistIgbinariesSerializer()
     {
-        $persister = new TheIconic\Fixtures\Persister\Redis\RedisPersister(
+        $persister = new RedisPersister(
             $_ENV['redis_host'],
             $_ENV['redis_port'],
             $_ENV['redis_db_number'],
@@ -68,7 +72,7 @@ class RedisPersisterTest extends \PHPUnit_Framework_TestCase
 
     public function testCleanStorage()
     {
-        $persister = new TheIconic\Fixtures\Persister\Redis\RedisPersister(
+        $persister = new RedisPersister(
             $_ENV['redis_host'],
             $_ENV['redis_port'],
             $_ENV['redis_db_number'],
@@ -87,7 +91,7 @@ class RedisPersisterTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidConnection()
     {
-        $persister = new TheIconic\Fixtures\Persister\Redis\RedisPersister(
+        $persister = new RedisPersister(
             'fake',
             $_ENV['redis_port'],
             $_ENV['redis_db_number'],

--- a/tests/TheIconic/Fixtures/Replacer/PlaceholderReplacerTest.php
+++ b/tests/TheIconic/Fixtures/Replacer/PlaceholderReplacerTest.php
@@ -1,10 +1,12 @@
 <?php
 
-namespace TheIconic\Fixtures\Replacer;
+namespace TheIconic\Test\Fixtures\Replacer;
 
+use PHPUnit\Framework\TestCase;
 use TheIconic\Fixtures\Parser\XmlParser;
+use TheIconic\Fixtures\Replacer\PlaceholderReplacer;
 
-class PlaceholderReplacerTest extends \PHPUnit_Framework_TestCase
+class PlaceholderReplacerTest extends TestCase
 {
     const TESTS_FIXTURES_DIRECTORY = '/../../../../tests/Support/TestsFixtures/';
 


### PR DESCRIPTION
- Conform to Iconic PHP Standards (Tests)
- Use Namespaced PHPUnit Testcase

