### PR TITLE
Expose Notifier Interface to announce fixture status

### DIFF
--- a/src/Notifier/NotifierInterface.php
+++ b/src/Notifier/NotifierInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace TheIconic\Fixtures\Notifier;
+
+use TheIconic\Fixtures\Fixture\Fixture;
+
+/**
+ * Interface NotifierInterface
+ * @package TheIconic\Fixtures\Notifier
+ */
+interface NotifierInterface
+{
+    /**
+     * Notifies if an individual fixture succeeded or failed
+     * 
+     * @param Fixture $fixture
+     * @param bool $success
+     * 
+     * @return void
+     */
+    public function notify(Fixture $fixture, $success);
+}

--- a/src/Notifier/NullNotifier.php
+++ b/src/Notifier/NullNotifier.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace TheIconic\Fixtures\Notifier;
+
+use TheIconic\Fixtures\Fixture\Fixture;
+
+/**
+ * Class NullNotifier
+ * @package TheIconic\Fixtures\Notifier
+ */
+class NullNotifier implements NotifierInterface
+{
+    /**
+     * Notifies if an individual fixture succeeded or failed
+     * 
+     * @param Fixture $fixture
+     * @param bool $success
+     * 
+     * @return void
+     */
+    public function notify(Fixture $fixture, $success)
+    {
+        
+    }
+}

--- a/tests/TheIconic/Fixtures/Notifier/NullNotifierTest.php
+++ b/tests/TheIconic/Fixtures/Notifier/NullNotifierTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TheIconic\Fixtures\Test\Replacer;
+
+use PHPUnit\Framework\TestCase;
+use TheIconic\Fixtures\Notifier\NullNotifier;
+
+class NullNotifierTest extends TestCase
+{
+    /**
+     * @var NullNotifier
+     */
+    private $notifierInstance;
+
+    public function setUp()
+    {
+        $this->notifierInstance = new NullNotifier();
+    }
+
+    public function testImplementsNotifierInstance()
+    {
+        $this->assertInstanceOf('TheIconic\Fixtures\Notifier\NotifierInterface', $this->notifierInstance);
+    }
+}


### PR DESCRIPTION
Exposes an interface called NotifierInterface, and call NotifierInterface::notify to notify individual fixture status. 

# Use case
I use this library to run my fixtures. However, I've to pass all the fixtures at once. I need to be able to get information about each of the fixtures succeeding or failing. 

PS: If you have any suggestions in regards to the Name, then please comment. I'll rename this.

PPS: Upon more thinking, I wonder if implementing a PSR Logger (and start writing logs) is better than this. :thinking:  **Open to discussions!**
